### PR TITLE
patch: reverted to v1.1.2

### DIFF
--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aptos-labs/aptos-protos": "^1.1.3",
+    "@aptos-labs/aptos-protos": "1.1.2",
     "@grpc/grpc-js": "^1.10.6",
     "@kade-net/hermes-tunnel": "workspace:^",
     "@kade/posthog": "workspace:^",

--- a/apps/indexer/workers/grpc-worker/worker.ts
+++ b/apps/indexer/workers/grpc-worker/worker.ts
@@ -40,7 +40,7 @@ export class Worker {
         let startingVersion = BigInt(0) // pass in the starting version;
         let currentStartingVersion = await this.db.getLatestVersion()
         console.log("Latest Version", currentStartingVersion)
-        if (currentStartingVersion > (_startingVersion ?? BigInt(0))) {
+        if (currentStartingVersion > (_startingVersion ?? 0n)) {
             startingVersion = currentStartingVersion
         } else {
             if (_startingVersion) {
@@ -49,7 +49,6 @@ export class Worker {
             await this.db.putVersion(startingVersion)
         }
 
-        console.log("Starting Version", startingVersion)
         const request: aptos.indexer.v1.GetTransactionsRequest = {
             startingVersion: startingVersion,
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
   apps/indexer:
     dependencies:
       '@aptos-labs/aptos-protos':
-        specifier: ^1.1.3
-        version: 1.1.3
+        specifier: 1.1.2
+        version: 1.1.2
       '@grpc/grpc-js':
         specifier: ^1.10.6
         version: 1.10.6
@@ -447,8 +447,8 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/aptos-protos@1.1.3:
-    resolution: {integrity: sha512-MfgdCX0eD9JLjxAUp4YLuYc9FCkjmzbAerNLR1bExGyTAaFYhdCGR6sETM140D5K1DyMB6OKu50p5L+jjcHzyw==}
+  /@aptos-labs/aptos-protos@1.1.2:
+    resolution: {integrity: sha512-DwOefasA9R9fY7KaPvVNETEeYwwruzsOfNBGlUZNzeeiJW6i79GNLPgoxL0sk6BlnuWqPkHzhRryq+IrSaJsaQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@grpc/grpc-js': 1.10.6


### PR DESCRIPTION
Reverted to v1.1.2 of indexer due to aptos upstream changes, causing crashes with the ts indexer