### PR TITLE
Updating talaria tables

### DIFF
--- a/packages/db/fill-test-values.ts
+++ b/packages/db/fill-test-values.ts
@@ -1,0 +1,183 @@
+import { contact, delegate, envelope, inbox, phonebook } from "./schema";
+import db from "./index";
+
+async function fillTestValues() {
+    try {
+        // Value with short address
+        await db.insert(phonebook).values({
+            address: "0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1",
+            hid: "100",
+            timestamp: new Date(),
+            public_key: "0xf9bfb67cc07af8e115e0acabe560faa9c63466fda76b806596ac62141253626"
+        });
+
+        // Values that depend on short address
+        await db.insert(contact).values({
+            id: "83bd9905-b827-4ac2-aeb9-7994b8018916",
+            address: "0xeaef3c98ef1d138fbedde9ad941ae7ecae800722e0d14842c5db3da64b5e35c",
+            user_address: "0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1", // We need to update user address here
+            accepted: true,
+            timestamp: new Date(),
+            envelope: {}
+        });
+
+        await db.insert(delegate).values({
+            address: "0xc7a738149ae16eb0882285713d781885dc1d281b2440e851f23a0093c75f5c6",
+            user_address: "0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1",
+            timestamp: new Date(),
+            hid: "100",
+            public_key: "0x2aaa26265fb89f7075f51798c204e9a27ca006b255e94013f38a00b3a5af154b",
+        })
+
+
+        // Good values
+        await db.insert(phonebook).values([{
+            address: "0x6d85963d424e44a6a85912d941997cb3f2bc8ae4fc74e32e9ac56b1501023ff8",
+            hid: "101",
+            timestamp: new Date(),
+            public_key: "0x4de611eff07041c1ac05e0fb8ad6e6415794cb4a1ae55aed95d465d1a2a701a"
+        }, {
+            address: "0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b",
+            hid: "102",
+            timestamp: new Date(),
+            public_key: "0x1d2d24514fa5c15833394cac3c947c858fab0278202c20bd7da3ecd253f71ff8"
+        }, {
+            address: "0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457",
+            hid: "103",
+            timestamp: new Date(),
+            public_key: "0x205d7d6c99a2c2c0570445bf0714cf86d70c741d7ce42bd4739f79f7996b72ee"
+        }]);
+
+
+        // Inserting inbox after creating other accounts
+        await db.insert(inbox).values({
+            id: "@0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1:@0xeaef3c98ef1d138fbedde9ad941ae7ecae800722e0d14842c5db3da64b5e35ca",
+            owner_address: "0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1",
+            initiator_address: "0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b",
+            timestamp: new Date(),
+            hid: "@0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1:@0xeaef3c98ef1d138fbedde9ad941ae7ecae800722e0d14842c5db3da64b5e35ca"
+        })
+
+        await db.insert(envelope).values({
+            id: "100",
+            ref: "inbox::@0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1:@0xeaef3c98ef1d138fbedde9ad941::1715195668839::0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457::dm",
+            timestamp: new Date(),
+            hid: "100",
+            inbox_name: "@0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1:@0xeaef3c98ef1d138fbedde9ad941ae7ecae800722e0d14842c5db3da64b5e35ca",
+            sender_public_key: "0x205d7d6c99a2c2c0570445bf0714cf86d70c741d7ce42bd4739f79f7996b72ee",
+            reciever_pubic_key: "0x1d2d24514fa5c15833394cac3c947c858fab0278202c20bd7da3ecd253f71ff8",
+            content: {},
+            sender: "0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1",
+            receiver: "0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457",
+            delegate_public_key: "0x2aaa26265fb89f7075f51798c204e9a27ca006b255e94013f38a00b3a5af154b",
+        })
+
+        await db.insert(contact).values([{
+            id: "83bd9905-b827-4ac2-aeb9-7994b8018917",
+            address: "0xebef3c98ef1d138fbedde9ad941ae7ecae800722e0d14842c5db3da64b5e35c",
+            user_address: "0x6d85963d424e44a6a85912d941997cb3f2bc8ae4fc74e32e9ac56b1501023ff8", // We need to update user address here
+            accepted: true,
+            timestamp: new Date(),
+            envelope: {}
+        }, {
+            id: "b89845f5-1f1f-4f0f-b0a4-75014b4db07d",
+            address: "0x838b4f43be8b7d94c0355c6e831775b99613847befce75a45491d136986ab688",
+            user_address: "0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b", // We need to update user address here
+            accepted: true,
+            timestamp: new Date(),
+            envelope: {}
+        }, {
+            id: "208ba3d2-9327-4c27-be4c-1774fd0393f8",
+            address: "0x2c4f4a1a466034cd345eb1ed197257d481907ffba5583c197384bf3eac447dbf",
+            user_address: "0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457", // We need to update user address here
+            accepted: true,
+            timestamp: new Date(),
+            envelope: {}
+        }]);
+
+        await db.insert(delegate).values([{
+            address: "0xa89087d77f00b61aee29cc097508815a7b5ca9b37beb10cbe02abe7941449702",
+            user_address: "0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b",
+            timestamp: new Date(),
+            hid: "101",
+            public_key: "0xad4ba545236342f3c1b362abb87d194f24630b82e9977b560622e23dd3be2148",
+        }, {
+            address: "0xccdb6677c494f7da549d0726a68717feb958fe1e6402aa060881b81cc478ba9",
+            user_address: "0x6d85963d424e44a6a85912d941997cb3f2bc8ae4fc74e32e9ac56b1501023ff8",
+            timestamp: new Date(),
+            hid: "102",
+            public_key: "0x62d8c622668a099a9288bc430618af061412153ac9f772d8a4445d53c8b1044",
+        }, {
+            address: "0xd68adb920a192fadd968b5d927383dfeff616b29c279c48b46f852f6373001a8",
+            user_address: "0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457",
+            timestamp: new Date(),
+            hid: "103",
+            public_key: "0xce0e17479f36c50237fec8ce5bb0224f16c65d87bd2201697eb5609fe9ee87d3",
+        }]);
+
+        await db.insert(inbox).values([{
+            id: "@0x6d85963d424e44a6a85912d941997cb3f2bc8ae4fc74e32e9ac56b1501023ff8:@0x838b4f43be8b7d94c0355c6e831775b99613847befce75a45491d136986ab688",
+            owner_address: "0x6d85963d424e44a6a85912d941997cb3f2bc8ae4fc74e32e9ac56b1501023ff8",
+            initiator_address: "0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1",
+            timestamp: new Date(),
+            hid: "@0x6d85963d424e44a6a85912d941997cb3f2bc8ae4fc74e32e9ac56b1501023ff8:@0x838b4f43be8b7d94c0355c6e831775b99613847befce75a45491d136986ab688"
+        } , {
+            id: "@0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b:@0x2c4f4a1a466034cd345eb1ed197257d481907ffba5583c197384bf3eac447dbf",
+            owner_address: "0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b",
+            initiator_address: "0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b",
+            timestamp: new Date(),
+            hid: "@0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b:@0x2c4f4a1a466034cd345eb1ed197257d481907ffba5583c197384bf3eac447dbf"
+        }, {
+            id: "@0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457:@0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b",
+            owner_address: "0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457",
+            initiator_address: "0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b",
+            timestamp: new Date(),
+            hid: "@0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457:@0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b"
+        }])
+
+        await db.insert(envelope).values([{
+            id: "101",
+            ref: "inbox::@0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1:@0xeaef3c98ef1d138fbedde9ad941::1715195668839::0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457::dm",
+            timestamp: new Date(),
+            hid: "101",
+            inbox_name: "@0x6d85963d424e44a6a85912d941997cb3f2bc8ae4fc74e32e9ac56b1501023ff8:@0x838b4f43be8b7d94c0355c6e831775b99613847befce75a45491d136986ab688",
+            sender_public_key: "0x205d7d6c99a2c2c0570445bf0714cf86d70c741d7ce42bd4739f79f7996b72ee",
+            reciever_pubic_key: "0x1d2d24514fa5c15833394cac3c947c858fab0278202c20bd7da3ecd253f71ff8",
+            content: {},
+            sender: "0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1",
+            receiver: "0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457",
+            delegate_public_key: "0x2aaa26265fb89f7075f51798c204e9a27ca006b255e94013f38a00b3a5af154b",
+        }, {
+            id: "102",
+            ref: "inbox::@0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457:@0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b::1715196778742::0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b::dm",
+            timestamp: new Date(),
+            hid: "102",
+            inbox_name: "@0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b:@0x2c4f4a1a466034cd345eb1ed197257d481907ffba5583c197384bf3eac447dbf",
+            sender_public_key: "0x205d7d6c99a2c2c0570445bf0714cf86d70c741d7ce42bd4739f79f7996b72ee",
+            reciever_pubic_key: "0x1d2d24514fa5c15833394cac3c947c858fab0278202c20bd7da3ecd253f71ff8",
+            content: {},
+            sender: "0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457",
+            receiver: "0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1",
+            delegate_public_key: "0x2aaa26265fb89f7075f51798c204e9a27ca006b255e94013f38a00b3a5af154b",
+        }, {
+            id: "103",
+            ref: "inbox::@0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1:@0xeaef3c98ef1d138fbedde9ad941::1715195668839::0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457::dm",
+            timestamp: new Date(),
+            hid: "103",
+            inbox_name: "@0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457:@0xd5bc50f9ae36a55c4e741919bea97c6443dff131581782d0979b2822d7d2db8b",
+            sender_public_key: "0x205d7d6c99a2c2c0570445bf0714cf86d70c741d7ce42bd4739f79f7996b72ee",
+            reciever_pubic_key: "0x1d2d24514fa5c15833394cac3c947c858fab0278202c20bd7da3ecd253f71ff8",
+            content: {},
+            sender: "0x2aaa26265fb89f7075f51798c204e9a27ca006b255e94013f38a00b3a5af154b",
+            receiver: "0x4667d24fe69f6bd9c5d4bb0ef828a28c3210c591cd72da5f8d7cb4b88252c457",
+            delegate_public_key: "0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1",
+        }])
+
+        console.log("Completed creating test fields");
+
+    } catch(err) {
+        console.log(err);
+    }
+}
+
+fillTestValues()

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres'
 import * as _schema from './schema'

--- a/packages/db/migrations/0001_classy_anthem.sql
+++ b/packages/db/migrations/0001_classy_anthem.sql
@@ -1,0 +1,38 @@
+ALTER TABLE "contact" DROP CONSTRAINT "contact_user_address_phonebook_address_fk";
+--> statement-breakpoint
+ALTER TABLE "delegate" DROP CONSTRAINT "delegate_user_address_phonebook_address_fk";
+--> statement-breakpoint
+ALTER TABLE "envelope" DROP CONSTRAINT "envelope_inbox_name_inbox_id_fk";
+--> statement-breakpoint
+ALTER TABLE "inbox" DROP CONSTRAINT "inbox_owner_address_phonebook_address_fk";
+ALTER TABLE "inbox" DROP CONSTRAINT "inbox_initiator_address_phonebook_address_fk";
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "contact" ADD CONSTRAINT "contact_user_address_phonebook_address_fk" FOREIGN KEY ("user_address") REFERENCES "phonebook"("address") ON DELETE no action ON UPDATE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "delegate" ADD CONSTRAINT "delegate_user_address_phonebook_address_fk" FOREIGN KEY ("user_address") REFERENCES "phonebook"("address") ON DELETE no action ON UPDATE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "envelope" ADD CONSTRAINT "envelope_inbox_name_inbox_id_fk" FOREIGN KEY ("inbox_name") REFERENCES "inbox"("id") ON DELETE no action ON UPDATE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "inbox" ADD CONSTRAINT "inbox_owner_address_phonebook_address_fk" FOREIGN KEY ("owner_address") REFERENCES "phonebook"("address") ON DELETE no action ON UPDATE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+ ALTER TABLE "inbox" ADD CONSTRAINT "inbox_initiator_address_phonebook_address_fk" FOREIGN KEY ("initiator_address") REFERENCES "phonebook"("address") ON DELETE no action ON UPDATE cascade;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/db/migrations/meta/0001_snapshot.json
+++ b/packages/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,343 @@
+{
+  "id": "9e81ce25-4f24-4c12-adb8-73bf12031d73",
+  "prevId": "e5c87110-e3e6-4d04-a8c3-f73081fa72b6",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contact_user_address_phonebook_address_fk": {
+          "name": "contact_user_address_phonebook_address_fk",
+          "tableFrom": "contact",
+          "tableTo": "phonebook",
+          "columnsFrom": [
+            "user_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "delegate": {
+      "name": "delegate",
+      "schema": "",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_address": {
+          "name": "user_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hid": {
+          "name": "hid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "delegate_user_address_phonebook_address_fk": {
+          "name": "delegate_user_address_phonebook_address_fk",
+          "tableFrom": "delegate",
+          "tableTo": "phonebook",
+          "columnsFrom": [
+            "user_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "phonebook": {
+      "name": "phonebook",
+      "schema": "",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hid": {
+          "name": "hid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phonebook_address_unique": {
+          "name": "phonebook_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        },
+        "phonebook_hid_unique": {
+          "name": "phonebook_hid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hid"
+          ]
+        }
+      }
+    },
+    "envelope": {
+      "name": "envelope",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hid": {
+          "name": "hid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbox_name": {
+          "name": "inbox_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_public_key": {
+          "name": "sender_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reciever_public_key": {
+          "name": "reciever_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender": {
+          "name": "sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver": {
+          "name": "receiver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_public_key": {
+          "name": "delegate_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "envelope_inbox_name_inbox_id_fk": {
+          "name": "envelope_inbox_name_inbox_id_fk",
+          "tableFrom": "envelope",
+          "tableTo": "inbox",
+          "columnsFrom": [
+            "inbox_name"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "inbox": {
+      "name": "inbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_address": {
+          "name": "owner_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiator_address": {
+          "name": "initiator_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hid": {
+          "name": "hid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "inbox_owner_address_phonebook_address_fk": {
+          "name": "inbox_owner_address_phonebook_address_fk",
+          "tableFrom": "inbox",
+          "tableTo": "phonebook",
+          "columnsFrom": [
+            "owner_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "inbox_initiator_address_phonebook_address_fk": {
+          "name": "inbox_initiator_address_phonebook_address_fk",
+          "tableFrom": "inbox",
+          "tableTo": "phonebook",
+          "columnsFrom": [
+            "initiator_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1714974075230,
       "tag": "0000_premium_the_order",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1719239610904,
+      "tag": "0001_classy_anthem",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/schema/inbox.ts
+++ b/packages/db/schema/inbox.ts
@@ -5,8 +5,8 @@ import { relations } from "drizzle-orm";
 
 export const inbox = pgTable("inbox", {
     id: text("id").notNull().primaryKey(), // follows the convention inbox_owner_address::delegate_address
-    owner_address: text("owner_address").notNull().references(() => phonebook.address),
-    initiator_address: text("initiator_address").notNull().references(() => phonebook.address),
+    owner_address: text("owner_address").notNull().references(() => phonebook.address, {onUpdate: 'cascade'}),
+    initiator_address: text("initiator_address").notNull().references(() => phonebook.address, {onUpdate: 'cascade'}),
     timestamp: timestamp("timestamp").notNull(),
     hid: text("hid").notNull(),
     active: boolean("active").notNull().default(false)
@@ -31,7 +31,7 @@ export const envelope = pgTable("envelope", {
     ref: text("ref").notNull(),
     timestamp: timestamp("timestamp").notNull(),
     hid: text("hid").notNull(),
-    inbox_name: text("inbox_name").notNull().references(() => inbox.id),
+    inbox_name: text("inbox_name").notNull().references(() => inbox.id, {onUpdate: 'cascade'}),
     sender_public_key: text("sender_public_key").notNull(),
     reciever_pubic_key: text("reciever_public_key").notNull(),
     content: json("content"),

--- a/packages/db/schema/phonebook.ts
+++ b/packages/db/schema/phonebook.ts
@@ -25,7 +25,7 @@ export const phonebookRelations = relations(phonebook, ({ many, one }) => {
 export const contact = pgTable("contact", {
     id: text("id").notNull().primaryKey(),
     address: text("address"),
-    user_address: text("user_address").notNull().references(() => phonebook.address),
+    user_address: text("user_address").notNull().references(() => phonebook.address, {onUpdate: 'cascade'}),
     accepted: boolean("accepted").notNull().default(false),
     timestamp: timestamp("timestamp").notNull(),
     envelope: json("envelope").notNull()
@@ -44,7 +44,7 @@ export const contactRelations = relations(contact, ({ many, one }) => {
 
 export const delegate = pgTable("delegate", {
     address: text("address").notNull().primaryKey(),
-    user_address: text("user_address").notNull().references(() => phonebook.address),
+    user_address: text("user_address").notNull().references(() => phonebook.address, {onUpdate: 'cascade'}),
     timestamp: timestamp("timestamp").notNull(),
     hid: text("hid").notNull(),
     public_key: text("public_key").notNull()

--- a/packages/db/select-faulty-phonebook-addresses.ts
+++ b/packages/db/select-faulty-phonebook-addresses.ts
@@ -1,18 +1,143 @@
 import { lt, sql } from "drizzle-orm";
-import { phonebook } from "./schema";
-import db from "./test-db";
+import { contact, delegate, envelope, phonebook } from "./schema";
+import db from ".";
 
 const addressSize = 66;
-async function getBadAddressesFromDB() {
+
+export const addressTransfomer = (p: string) => {
+    const address = p
+    // Check if address is less than 66 char long
+    if (typeof p == 'string' && p.length < addressSize) {
+        // Add the necessary padding
+        let paddingAmount = addressSize - p.length;
+
+        // Add padding
+        let padding = "0".repeat(paddingAmount);
+        const newAddress = p.replace("0x", "0x" + padding);
+        return newAddress;
+    }
+    return address
+}
+
+
+export default async function getBadPhoneAddressesFromDB(): Promise<string[]> {
     try {
         let results = await db.select({
             address: phonebook.address
         }).from(phonebook)
         .where(sql`length(address) < ${addressSize}`)
-        console.log(results);
+        
+        console.log("Phonebook addresses to be updated are: ", results);
+        let addresses: string[] = [];
+
+        for (let i = 0; i < results.length; i++) {
+            addresses.push(results[i]['address']);
+        }
+        
+        return addresses;
     } catch(err) {
         console.log(err);
+        throw "Could Not Get Addresses";
     }
 }
 
-getBadAddressesFromDB();
+export async function getBadPhonePubKeyFromDB(): Promise<string[]> {
+    try {
+        let results = await db.select({
+            public_key: phonebook.public_key
+        }).from(phonebook)
+        .where(sql`length(public_key) < ${addressSize}`)
+        
+        console.log("Phonebook pub keys to be updated are: ", results);
+        let addresses: string[] = [];
+
+        for (let i = 0; i < results.length; i++) {
+            let res = results[i];
+            if (res) {
+                addresses.push(res['public_key']!);
+            }
+        }
+        
+        return addresses;
+    } catch(err) {
+        console.log(err);
+        throw "Could Not Get Phonebook Pub keys";
+    }
+}
+
+export async function getBadContactAddrFromDB(): Promise<string[]> {
+    try {
+        let results = await db.select({
+            address: contact.address
+        }).from(contact)
+        .where(sql`length(address) < ${addressSize}`)
+        
+        console.log("Contact addresses to be updated are: ", results);
+        let addresses: string[] = [];
+
+        for (let i = 0; i < results.length; i++) {
+            let res = results[i];
+            if (res) {
+                addresses.push(res['address']!);
+            }
+        }
+        
+        return addresses;
+    } catch(err) {
+        console.log(err);
+        throw "Could Not Get Contact Addresses";
+    }
+}
+
+export async function getBadAddrPubKeyDelegateFromDB(): Promise<{address: string, public_key: string}[]> {
+    try {
+        let results = await db.select({
+            address: delegate.address,
+            public_key: delegate.public_key
+        }).from(delegate)
+        .where(sql`length(address) < ${addressSize} OR length(public_key) < ${addressSize}`)
+        
+        console.log("Delegate addresses or pub keys to be updated are: ", results);
+        let addresses: {address: string, public_key: string}[] = [];
+
+        for (let i = 0; i < results.length; i++) {
+            let res = results[i];
+            if (res) {
+                addresses.push({address: res['address'], public_key: res['public_key']});
+            }
+        }
+        
+        return addresses;
+    } catch(err) {
+        console.log(err);
+        throw "Could Not Get Delegate Addresses";
+    }
+}
+
+export async function getBadEnvelopeKeysFromDB(): Promise<{sender_public_key: string, reciever_public_key: string, sender: string, receiver: string, delegate_public_key: string}[]> {
+    try {
+        let results = await db.select({
+            sender_public_key: envelope.sender_public_key,
+            sender: envelope.sender,
+            receiver: envelope.receiver,
+            delegate_public_key: envelope.delegate_public_key,
+            reciever_public_key: envelope.reciever_pubic_key
+        }).from(envelope)
+        .where(sql`length(sender_public_key) < ${addressSize} OR length(sender) < ${addressSize} OR length(receiver) < ${addressSize} OR length(delegate_public_key) < ${addressSize} OR length(reciever_public_key) < ${addressSize}`)
+        
+        console.log("Envelope addresses to be updated are: ", results);
+        let addresses: {sender_public_key: string, reciever_public_key: string, sender: string, receiver: string, delegate_public_key: string}[] = [];
+
+        for (let i = 0; i < results.length; i++) {
+            let res = results[i];
+            if (res) {
+                addresses.push({sender_public_key: res['sender_public_key'], reciever_public_key: res['reciever_public_key'], sender: res['sender'], receiver: res['receiver'], delegate_public_key: res['delegate_public_key'] ?? ""});
+            }
+        }
+        
+        return addresses;
+    } catch(err) {
+        console.log(err);
+        throw "Could Not Get Envelope Addresses";
+    }
+}

--- a/packages/db/select-faulty-phonebook-addresses.ts
+++ b/packages/db/select-faulty-phonebook-addresses.ts
@@ -1,0 +1,18 @@
+import { lt, sql } from "drizzle-orm";
+import { phonebook } from "./schema";
+import db from "./test-db";
+
+const addressSize = 66;
+async function getBadAddressesFromDB() {
+    try {
+        let results = await db.select({
+            address: phonebook.address
+        }).from(phonebook)
+        .where(sql`length(address) < ${addressSize}`)
+        console.log(results);
+    } catch(err) {
+        console.log(err);
+    }
+}
+
+getBadAddressesFromDB();

--- a/packages/db/update-table.ts
+++ b/packages/db/update-table.ts
@@ -1,0 +1,165 @@
+
+
+import { eq, sql } from "drizzle-orm";
+import db from ".";
+import { contact, delegate, envelope, inbox, phonebook } from "./schema";
+import getBadPhoneAddressesFromDB, { addressTransfomer, getBadAddrPubKeyDelegateFromDB, getBadContactAddrFromDB, getBadEnvelopeKeysFromDB, getBadPhonePubKeyFromDB } from "./select-faulty-phonebook-addresses";
+
+async function updateTables() {
+    try {
+        let addresses = await updateAddressesInPhonebook();
+        await updatePubkeysInPhonebook();
+        await updateAddrInContact();
+        await updateAddrPubKeyInDelegate();
+        await updateInboxID(addresses);
+        await updateEnvelopeAddresses();
+
+        console.log("Talaria updates complete")
+    } catch(err) {
+
+    }
+}
+
+async function updateAddressesInPhonebook(): Promise<string[]> {
+    try {
+        // Get tables to update
+        let addresses = await getBadPhoneAddressesFromDB();
+
+        for (let i = 0; i < addresses.length; i++) {
+            let addr = addresses[i];
+            let goodAddr = addressTransfomer(addr);
+            await db.update(phonebook).set({address: goodAddr})
+                .where(eq(phonebook.address, addr))
+        }
+
+        console.log("update phonebook address complete");
+        return addresses;
+    } catch(err) {
+        console.log(err);
+        throw "Could Not update phonebook address";
+    }
+}
+
+async function updatePubkeysInPhonebook() {
+    try {
+        // Get tables to update
+        let addresses = await getBadPhonePubKeyFromDB();
+
+        for (let i = 0; i < addresses.length; i++) {
+            let addr = addresses[i];
+            let goodAddr = addressTransfomer(addr);
+            await db.update(phonebook).set({public_key: goodAddr})
+                .where(eq(phonebook.public_key, addr))
+        }
+
+        console.log("update phonebook public key complete");
+    } catch(err) {
+        console.log(err);
+        throw "Could Not update phonebook public key";
+    }
+}
+
+async function updateAddrInContact() {
+    try {
+        // Get tables to update
+        let addresses = await getBadContactAddrFromDB();
+
+        for (let i = 0; i < addresses.length; i++) {
+            let addr = addresses[i];
+            let goodAddr = addressTransfomer(addr);
+            await db.update(contact).set({address: goodAddr})
+                .where(eq(contact.address, addr))
+        }
+
+        console.log("update contact address complete");
+    } catch(err) {
+        console.log(err);
+        throw "Could not update contact address";
+    }
+}
+
+async function updateAddrPubKeyInDelegate() {
+    try {
+        // Get tables to update
+        let addresses = await getBadAddrPubKeyDelegateFromDB();
+
+        for (let i = 0; i < addresses.length; i++) {
+            let addr = addresses[i];
+            let goodAddr = addressTransfomer(addr.address);
+            let goodPubkey = addressTransfomer(addr.public_key)
+            await db.update(delegate).set({address: goodAddr, public_key: goodPubkey})
+                .where(sql`address = ${addr.address} AND public_key = ${addr.public_key}`)
+        }
+
+        console.log("update delegate address and public key complete");
+    } catch(err) {
+        console.log(err);
+        throw "Could Not update delegate address and public key";
+    }
+}
+
+async function updateInboxID(updatedAddresses: string[]) {
+    try {
+        for (let i = 0; i < updatedAddresses.length; i++) {
+            let addr = addressTransfomer(updatedAddresses[i]);
+    
+            // Select id, owner_address and initiator_address of entries with id
+            let results = await db.select({
+                id: inbox.id,
+                owner_address: inbox.owner_address,
+                initiator_address: inbox.initiator_address
+            }).from(inbox)
+            .where(sql`owner_address = ${addr} OR initiator_address = ${addr}`);
+    
+            if (results.length > 0) {
+                // For each result update id
+                for (let j = 0; j < results.length; j++) {
+                    let res = results[j];
+                    let oldID = res['id'];
+                    let owner_address = res['owner_address'];
+                    let initiator_address = res['initiator_address'];
+                    let newID = `@${owner_address}:@${initiator_address}`;
+    
+                    await db.update(inbox).set({id: newID, hid: newID}).where(eq(inbox.id, oldID))
+                }
+            }
+        }
+        console.log("update inbox id and hid complete");
+    } catch(err) {
+        throw "Could Not update inbox id and hid";
+    }
+}
+
+async function updateEnvelopeAddresses() {
+    try {
+        // Get tables to update
+        let addresses = await getBadEnvelopeKeysFromDB();
+
+        for (let i = 0; i < addresses.length; i++) {
+            let addr = addresses[i];
+            let newDelegatePubkey = "";
+            if (addr['delegate_public_key'] != null && addr['delegate_public_key'] != "") {
+                newDelegatePubkey = addressTransfomer(addr['delegate_public_key']);
+            }
+
+            let newAddr = {
+                sender_public_key: addressTransfomer(addr['sender_public_key']),
+                reciever_public_key: addressTransfomer(addr['reciever_public_key']),
+                sender: addressTransfomer(addr['sender']),
+                receiver: addressTransfomer(addr['receiver']),
+                delegate_public_key: newDelegatePubkey
+            };
+            await db.update(envelope).set(newAddr)
+                .where(sql`sender_public_key = ${addr['sender_public_key']} AND reciever_public_key = ${addr['reciever_public_key']} AND sender = ${addr['sender']} AND receiver = ${addr['receiver']} AND delegate_public_key = ${addr['delegate_public_key']}`)
+        }
+
+        console.log("update envelope addresses complete");
+    } catch(err) {
+        console.log(err);
+        throw "Could Not update envelope addresses";
+    }
+}
+
+
+
+updateTables();

--- a/packages/schema/events/index.ts
+++ b/packages/schema/events/index.ts
@@ -1,10 +1,25 @@
 import { z } from "zod";
 
+const addressSize = 66;
+const addressTransfomer = (p: string) => {
+    const address = p
+    // Check if address is less than 66 char long
+    if (typeof p == 'string' && p.length < addressSize) {
+        // Add the necessary padding
+        let paddingAmount = addressSize - p.length;
+
+        // Add padding
+        let padding = "0".repeat(paddingAmount);
+        const newAddress = p.replace("0x", "0x" + padding);
+        return newAddress;
+    }
+    return address
+}
 const transformStringToDate = (v: string) => new Date(parseInt(v) / 1000)
 
 export const envelope = z.object({
-    sender: z.string(),
-    receiver: z.string(),
+    sender: z.string().transform(addressTransfomer),
+    receiver: z.string().transform(addressTransfomer),
     content: z.string(),
     timestamp: z.string().transform(transformStringToDate),
     hid: z.string().transform(v => parseInt(v)),
@@ -16,52 +31,52 @@ export const envelope = z.object({
 })
 
 export const request_inbox_register_event = z.object({
-    user_address: z.string(),
+    user_address: z.string().transform(addressTransfomer),
     timestamp: z.string().transform(transformStringToDate),
     hid: z.string().transform(v => parseInt(v)),
     public_key: z.string()
 })
 
 export const request_event = z.object({
-    requester_address: z.string(),
-    inbox_owner_address: z.string(),
+    requester_address: z.string().transform(addressTransfomer),
+    inbox_owner_address: z.string().transform(addressTransfomer),
     envelope: z.string(),
     timestamp: z.string().transform(transformStringToDate),
     inbox_name: z.string()
 })
 
 export const accept_request_event = z.object({
-    requester_address: z.string(),
-    inbox_owner_address: z.string(),
+    requester_address: z.string().transform(addressTransfomer),
+    inbox_owner_address: z.string().transform(addressTransfomer),
     timestamp: z.string().transform(transformStringToDate),
     inbox_name: z.string()
 })
 
 export const request_denied_event = z.object({
-    requester_address: z.string(),
-    inbox_owner_address: z.string(),
+    requester_address: z.string().transform(addressTransfomer),
+    inbox_owner_address: z.string().transform(addressTransfomer),
     timestamp: z.string().transform(transformStringToDate),
     inbox_name: z.string()
 })
 
 export const request_remove_from_phonebook_event = z.object({
-    requester_address: z.string(),
-    inbox_owner_address: z.string(),
+    requester_address: z.string().transform(addressTransfomer),
+    inbox_owner_address: z.string().transform(addressTransfomer),
     timestamp: z.string().transform(transformStringToDate),
     inbox_name: z.string()
 })
 
 export const delegate_register_event = z.object({
-    owner: z.string(),
+    owner: z.string().transform(addressTransfomer),
     delegate_hid: z.string(),
     user_hid: z.string(),
-    delegate_address: z.string(),
+    delegate_address: z.string().transform(addressTransfomer),
     public_key: z.string(),
 })
 
 export const delegate_remove_event = z.object({
-    delegate_address: z.string(),
+    delegate_address: z.string().transform(addressTransfomer),
     delegate_hid: z.string(),
-    owner_address: z.string(),
+    owner_address: z.string().transform(addressTransfomer),
     owner_hid: z.string()
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,7 +153,7 @@ importers:
         version: 3.4.4
       tsup:
         specifier: ^8.0.2
-        version: 8.0.2(ts-node@10.9.2)(typescript@5.4.5)
+        version: 8.0.2(typescript@5.4.5)
     devDependencies:
       '@types/node':
         specifier: ^20.12.7
@@ -492,6 +492,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    dev: true
 
   /@esbuild-kit/core-utils@3.3.2:
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -1008,6 +1009,7 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /@js-sdsl/ordered-map@4.4.2:
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -1266,15 +1268,19 @@ packages:
 
   /@tsconfig/node10@1.0.11:
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+    dev: true
 
   /@tsconfig/node12@1.0.11:
     resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
 
   /@tsconfig/node14@1.0.3:
     resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
 
   /@tsconfig/node16@1.0.4:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: true
 
   /@types/body-parser@1.19.5:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
@@ -1415,11 +1421,13 @@ packages:
   /acorn-walk@8.3.2:
     resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
+    dev: true
 
   /acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: true
 
   /agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -1490,6 +1498,7 @@ packages:
 
   /arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1775,6 +1784,7 @@ packages:
 
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
 
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -1801,6 +1811,18 @@ packages:
         optional: true
     dependencies:
       ms: 2.0.0
+    dev: false
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
     dev: false
 
   /debug@4.3.4(supports-color@5.5.0):
@@ -1885,6 +1907,7 @@ packages:
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
+    dev: true
 
   /diff@5.0.0:
     resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
@@ -2104,7 +2127,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       esbuild: 0.19.12
     transitivePeerDependencies:
       - supports-color
@@ -3219,6 +3242,22 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
 
+  /postcss-load-config@4.0.2:
+    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 3.1.1
+      yaml: 2.4.1
+    dev: false
+
   /postcss-load-config@4.0.2(ts-node@10.9.2):
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
@@ -3234,6 +3273,7 @@ packages:
       lilconfig: 3.1.1
       ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
       yaml: 2.4.1
+    dev: true
 
   /postgres@3.4.4:
     resolution: {integrity: sha512-IbyN+9KslkqcXa8AO9fxpk97PA4pzewvpi2B3Dwy9u4zpV32QicaEdgmF3eSQUzdRk7ttDHQejNgAEr4XoeH4A==}
@@ -3769,6 +3809,7 @@ packages:
       typescript: 5.4.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: true
 
   /ts-node@7.0.1:
     resolution: {integrity: sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==}
@@ -3837,6 +3878,46 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - ts-node
+    dev: true
+
+  /tsup@8.0.2(typescript@5.4.5):
+    resolution: {integrity: sha512-NY8xtQXdH7hDUAZwcQdY/Vzlw9johQsaqf7iwZ6g1DOUlFYQ5/AtVAjTvihhEyeRlGo4dLRVHtrRaL35M1daqQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.0.3(esbuild@0.19.12)
+      cac: 6.7.14
+      chokidar: 3.5.3
+      debug: 4.3.4
+      esbuild: 0.19.12
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 4.0.2
+      resolve-from: 5.0.0
+      rollup: 4.16.4
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tree-kill: 1.2.2
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: false
 
   /tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
@@ -3895,6 +3976,7 @@ packages:
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
 
   /value-or-promise@1.0.12:
     resolution: {integrity: sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==}
@@ -4031,6 +4113,7 @@ packages:
   /yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
+    dev: true
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}


### PR DESCRIPTION
- Contains changes to the tables. I've added update cascade relationships on foreign keys to allow an update on a column such as address in phonebook table to propogate to all the tables that have a foreign key relationship to it
- Contains the script that will update the tables i.e update-table.ts
- Contains scripts you can use for testing i.e fill-tables.ts
- To test the script:
1. Create or use a local postgres instance
2. Set the PG_CONNECTION_STRING env variable to the connection string of the local instance
3. Run the migrations
4. Run the fill-tables.ts file. This fills your local postgres instance with sample data from testnet. Some of the addresses in it are shorther than 64 characters e.g 0x69c18fb0d693ec30118535e3852763034a595977daa6ebeead254e5f54a7bd1
5. Run the update-tables.ts file. This updates the following
- Address column in phonebook table that propogates to all tables that have it as a foreign key (i.e user_address column in contacts, user_address column in delegates, owner_address and initiator_address in inbox)
- Address column in contact table
- Address and public key columns in delegates table
- id column in inbox since I saw you base it off of owner_address and initiator_address (inbox_name column of envelope table has foreign key constraint to this table and is updated as well)
- sender_public_key, receiver_public_key, sender, receiver, delegate_public_key columns of envelope table

After testing PG_CONNECTION_STRING can be changed to that of testnet or prod to run the script on those environments